### PR TITLE
Fix error when mounting multiple Rack apps.

### DIFF
--- a/lib/docushin/route_set.rb
+++ b/lib/docushin/route_set.rb
@@ -12,7 +12,7 @@ module Docushin
         if (rack_app = discover_rack_app(route.app)) && rack_app.respond_to?(:routes)
           rack_app.routes.routes.each do |rack_route|
             add_route Route.new(rack_route)
-          end
+          end if rack_app.routes.respond_to?(:routes)
         end
 
         add_route Route.new(route)


### PR DESCRIPTION
``` ruby
mount Sidekiq::Web, at: 'sidekiq'
mount Docushin::Engine, at: 'doc'
```

 `undefined method `routes' for #<Hash:0x007fd023518b50>`
